### PR TITLE
Remove unneeded ui

### DIFF
--- a/CactbotOverlay/CactbotEventSource.cs
+++ b/CactbotOverlay/CactbotEventSource.cs
@@ -178,10 +178,8 @@ namespace Cactbot {
       OnGameExists += (e) => DispatchToJS(e);
       OnGameActiveChanged += (e) => DispatchToJS(e);
       OnZoneChanged += (e) => DispatchToJS(e);
-      if (this.Config.LogUpdatesEnabled) {
-        OnLogsChanged += (e) => DispatchToJS(e);
-        OnImportLogsChanged += (e) => DispatchToJS(e);
-      }
+      OnLogsChanged += (e) => DispatchToJS(e);
+      OnImportLogsChanged += (e) => DispatchToJS(e);
       OnPlayerChanged += (e) => DispatchToJS(e);
       OnTargetChanged += (e) => DispatchToJS(e);
       OnFocusChanged += (e) => DispatchToJS(e);

--- a/CactbotOverlay/CactbotEventSourceConfig.cs
+++ b/CactbotOverlay/CactbotEventSourceConfig.cs
@@ -39,15 +39,7 @@ namespace Cactbot {
       if (pluginConfig.EventSourceConfigs.ContainsKey("CactbotESConfig")) {
         var obj = pluginConfig.EventSourceConfigs["CactbotESConfig"];
 
-        if (obj.TryGetValue("LogUpdatesEnabled", out JToken value)) {
-          result.LogUpdatesEnabled = value.ToObject<bool>();
-        }
-
-        if (obj.TryGetValue("DpsUpdatesPerSecond", out value)) {
-          result.DpsUpdatesPerSecond = value.ToObject<double>();
-        }
-
-        if (obj.TryGetValue("OverlayData", out value)) {
+        if (obj.TryGetValue("OverlayData", out JToken value)) {
           result.OverlayData = value.ToObject<Dictionary<string, string>>();
         }
 
@@ -70,10 +62,6 @@ namespace Cactbot {
     public void SaveConfig(IPluginConfig pluginConfig) {
       pluginConfig.EventSourceConfigs["CactbotESConfig"] = JObject.FromObject(this);
     }
-    
-    public bool LogUpdatesEnabled = true;
-
-    public double DpsUpdatesPerSecond = 0;
 
     public Dictionary<string, string> OverlayData = null;
     

--- a/CactbotOverlay/CactbotEventSourceConfigPanel.Designer.cs
+++ b/CactbotOverlay/CactbotEventSourceConfigPanel.Designer.cs
@@ -17,138 +17,94 @@
 
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CactbotEventSourceConfigPanel));
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.dpsUpdateRateLabel = new System.Windows.Forms.Label();
-            this.dpsUpdateRate = new System.Windows.Forms.TextBox();
-            this.logUpdateLabel = new System.Windows.Forms.Label();
-            this.logUpdateCheckBox = new System.Windows.Forms.CheckBox();
-            this.restartMessageLabel = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-            this.buttonSelectUserConfigFile = new System.Windows.Forms.Button();
-            this.textUserConfigFile = new System.Windows.Forms.TextBox();
-            this.labelDevReloader = new System.Windows.Forms.Label();
-            this.checkWatchFileChanges = new System.Windows.Forms.CheckBox();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.tableLayoutPanel4.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // tableLayoutPanel1
-            // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 1, 14);
-            this.tableLayoutPanel1.Controls.Add(this.dpsUpdateRateLabel, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.dpsUpdateRate, 1, 8);
-            this.tableLayoutPanel1.Controls.Add(this.logUpdateLabel, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.logUpdateCheckBox, 1, 9);
-            this.tableLayoutPanel1.Controls.Add(this.restartMessageLabel, 1, 10);
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 12);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 1, 12);
-            this.tableLayoutPanel1.Controls.Add(this.labelDevReloader, 0, 13);
-            this.tableLayoutPanel1.Controls.Add(this.checkWatchFileChanges, 1, 13);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // tableLayoutPanel3
-            // 
-            resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            // 
-            // dpsUpdateRateLabel
-            // 
-            resources.ApplyResources(this.dpsUpdateRateLabel, "dpsUpdateRateLabel");
-            this.dpsUpdateRateLabel.Name = "dpsUpdateRateLabel";
-            // 
-            // dpsUpdateRate
-            // 
-            resources.ApplyResources(this.dpsUpdateRate, "dpsUpdateRate");
-            this.dpsUpdateRate.Name = "dpsUpdateRate";
-            this.dpsUpdateRate.Validating += new System.ComponentModel.CancelEventHandler(this.dpsUpdateRate_Validating);
-            this.dpsUpdateRate.Validated += new System.EventHandler(this.dpsUpdateRate_Validated);
-            // 
-            // logUpdateLabel
-            // 
-            resources.ApplyResources(this.logUpdateLabel, "logUpdateLabel");
-            this.logUpdateLabel.Name = "logUpdateLabel";
-            // 
-            // logUpdateCheckBox
-            // 
-            resources.ApplyResources(this.logUpdateCheckBox, "logUpdateCheckBox");
-            this.logUpdateCheckBox.Name = "logUpdateCheckBox";
-            this.logUpdateCheckBox.UseVisualStyleBackColor = true;
-            this.logUpdateCheckBox.CheckedChanged += new System.EventHandler(this.logUpdateCheckBox_CheckedChanged);
-            // 
-            // restartMessageLabel
-            // 
-            resources.ApplyResources(this.restartMessageLabel, "restartMessageLabel");
-            this.restartMessageLabel.Name = "restartMessageLabel";
-            // 
-            // label1
-            // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
-            // 
-            // tableLayoutPanel4
-            // 
-            resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
-            this.tableLayoutPanel4.Controls.Add(this.buttonSelectUserConfigFile, 0, 0);
-            this.tableLayoutPanel4.Controls.Add(this.textUserConfigFile, 0, 0);
-            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
-            // 
-            // buttonSelectUserConfigFile
-            // 
-            resources.ApplyResources(this.buttonSelectUserConfigFile, "buttonSelectUserConfigFile");
-            this.buttonSelectUserConfigFile.Name = "buttonSelectUserConfigFile";
-            this.buttonSelectUserConfigFile.UseVisualStyleBackColor = true;
-            this.buttonSelectUserConfigFile.Click += new System.EventHandler(this.buttonSelectUserConfigFile_Click);
-            // 
-            // textUserConfigFile
-            // 
-            resources.ApplyResources(this.textUserConfigFile, "textUserConfigFile");
-            this.textUserConfigFile.Name = "textUserConfigFile";
-            this.textUserConfigFile.Leave += new System.EventHandler(this.textUserConfigFile_Leave);
-            // 
-            // labelDevReloader
-            // 
-            resources.ApplyResources(this.labelDevReloader, "labelDevReloader");
-            this.labelDevReloader.Name = "labelDevReloader";
-            // 
-            // checkWatchFileChanges
-            // 
-            resources.ApplyResources(this.checkWatchFileChanges, "checkWatchFileChanges");
-            this.checkWatchFileChanges.Name = "checkWatchFileChanges";
-            this.checkWatchFileChanges.UseVisualStyleBackColor = true;
-            this.checkWatchFileChanges.CheckedChanged += new System.EventHandler(this.checkWatchFileChanges_CheckedChanged);
-            // 
-            // CactbotEventSourceConfigPanel
-            // 
-            resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Name = "CactbotEventSourceConfigPanel";
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.tableLayoutPanel4.ResumeLayout(false);
-            this.tableLayoutPanel4.PerformLayout();
-            this.ResumeLayout(false);
+      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CactbotEventSourceConfigPanel));
+      this.checkWatchFileChanges = new System.Windows.Forms.CheckBox();
+      this.labelDevReloader = new System.Windows.Forms.Label();
+      this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+      this.textUserConfigFile = new System.Windows.Forms.TextBox();
+      this.buttonSelectUserConfigFile = new System.Windows.Forms.Button();
+      this.label1 = new System.Windows.Forms.Label();
+      this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+      this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+      this.tableLayoutPanel4.SuspendLayout();
+      this.tableLayoutPanel1.SuspendLayout();
+      this.SuspendLayout();
+      // 
+      // checkWatchFileChanges
+      // 
+      resources.ApplyResources(this.checkWatchFileChanges, "checkWatchFileChanges");
+      this.checkWatchFileChanges.Name = "checkWatchFileChanges";
+      this.checkWatchFileChanges.UseVisualStyleBackColor = true;
+      this.checkWatchFileChanges.CheckedChanged += new System.EventHandler(this.checkWatchFileChanges_CheckedChanged);
+      // 
+      // labelDevReloader
+      // 
+      resources.ApplyResources(this.labelDevReloader, "labelDevReloader");
+      this.labelDevReloader.Name = "labelDevReloader";
+      // 
+      // tableLayoutPanel4
+      // 
+      resources.ApplyResources(this.tableLayoutPanel4, "tableLayoutPanel4");
+      this.tableLayoutPanel4.Controls.Add(this.buttonSelectUserConfigFile, 0, 0);
+      this.tableLayoutPanel4.Controls.Add(this.textUserConfigFile, 0, 0);
+      this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+      // 
+      // textUserConfigFile
+      // 
+      resources.ApplyResources(this.textUserConfigFile, "textUserConfigFile");
+      this.textUserConfigFile.Name = "textUserConfigFile";
+      this.textUserConfigFile.Leave += new System.EventHandler(this.textUserConfigFile_Leave);
+      // 
+      // buttonSelectUserConfigFile
+      // 
+      resources.ApplyResources(this.buttonSelectUserConfigFile, "buttonSelectUserConfigFile");
+      this.buttonSelectUserConfigFile.Name = "buttonSelectUserConfigFile";
+      this.buttonSelectUserConfigFile.UseVisualStyleBackColor = true;
+      this.buttonSelectUserConfigFile.Click += new System.EventHandler(this.buttonSelectUserConfigFile_Click);
+      // 
+      // label1
+      // 
+      resources.ApplyResources(this.label1, "label1");
+      this.label1.Name = "label1";
+      // 
+      // tableLayoutPanel3
+      // 
+      resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
+      this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+      // 
+      // tableLayoutPanel1
+      // 
+      resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+      this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 1, 14);
+      this.tableLayoutPanel1.Controls.Add(this.label1, 0, 12);
+      this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 1, 12);
+      this.tableLayoutPanel1.Controls.Add(this.labelDevReloader, 0, 13);
+      this.tableLayoutPanel1.Controls.Add(this.checkWatchFileChanges, 1, 13);
+      this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+      // 
+      // CactbotEventSourceConfigPanel
+      // 
+      resources.ApplyResources(this, "$this");
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.tableLayoutPanel1);
+      this.Name = "CactbotEventSourceConfigPanel";
+      this.tableLayoutPanel4.ResumeLayout(false);
+      this.tableLayoutPanel4.PerformLayout();
+      this.tableLayoutPanel1.ResumeLayout(false);
+      this.tableLayoutPanel1.PerformLayout();
+      this.ResumeLayout(false);
 
         }
 
-        #endregion
+    #endregion
 
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.Label dpsUpdateRateLabel;
-        private System.Windows.Forms.TextBox dpsUpdateRate;
-        private System.Windows.Forms.Label logUpdateLabel;
-        private System.Windows.Forms.CheckBox logUpdateCheckBox;
-        private System.Windows.Forms.Label restartMessageLabel;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
-        private System.Windows.Forms.Button buttonSelectUserConfigFile;
-        private System.Windows.Forms.TextBox textUserConfigFile;
-        private System.Windows.Forms.Label labelDevReloader;
-        private System.Windows.Forms.CheckBox checkWatchFileChanges;
-    }
+    private System.Windows.Forms.CheckBox checkWatchFileChanges;
+    private System.Windows.Forms.Label labelDevReloader;
+    private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
+    private System.Windows.Forms.Button buttonSelectUserConfigFile;
+    private System.Windows.Forms.TextBox textUserConfigFile;
+    private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+    private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+  }
 }

--- a/CactbotOverlay/CactbotEventSourceConfigPanel.cs
+++ b/CactbotOverlay/CactbotEventSourceConfigPanel.cs
@@ -18,8 +18,6 @@ namespace Cactbot {
     }
 
     private void SetupControlProperties() {
-      this.dpsUpdateRate.Text = Convert.ToString(config.DpsUpdatesPerSecond, CultureInfo.InvariantCulture);
-      this.logUpdateCheckBox.Checked = config.LogUpdatesEnabled;
       this.textUserConfigFile.Text = config.UserConfigFile;
       this.checkWatchFileChanges.Checked = config.WatchFileChanges;
     }
@@ -34,23 +32,6 @@ namespace Cactbot {
       } else {
         action();
       }
-    }
-
-    private void dpsUpdateRate_Validating(object sender, System.ComponentModel.CancelEventArgs e) {
-      try {
-        Convert.ToDouble(dpsUpdateRate.Text, CultureInfo.InvariantCulture);
-      } catch {
-        e.Cancel = true;
-        dpsUpdateRate.Select(0, dpsUpdateRate.Text.Length);
-      }
-    }
-
-    private void dpsUpdateRate_Validated(object sender, EventArgs e) {
-      this.config.DpsUpdatesPerSecond = Convert.ToDouble(dpsUpdateRate.Text, CultureInfo.InvariantCulture);
-    }
-
-    private void logUpdateCheckBox_CheckedChanged(object sender, EventArgs e) {
-      this.config.LogUpdatesEnabled = logUpdateCheckBox.Checked;
     }
 
     private void buttonSelectUserConfigFile_Click(object sender, EventArgs e) {

--- a/CactbotOverlay/CactbotEventSourceConfigPanel.resx
+++ b/CactbotOverlay/CactbotEventSourceConfigPanel.resx
@@ -117,233 +117,71 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="checkWatchFileChanges.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>208, 101</value>
-  </data>
-  <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>353, 496</value>
-  </data>
-  <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
-    <value>tableLayoutPanel3</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls /&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="dpsUpdateRateLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
-  </data>
-  <data name="dpsUpdateRateLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="dpsUpdateRateLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="checkWatchFileChanges.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="dpsUpdateRateLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="checkWatchFileChanges.Location" type="System.Drawing.Point, System.Drawing">
+    <value>208, 26</value>
   </data>
-  <data name="dpsUpdateRateLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 22</value>
+  <data name="checkWatchFileChanges.Size" type="System.Drawing.Size, System.Drawing">
+    <value>353, 14</value>
   </data>
-  <data name="dpsUpdateRateLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="checkWatchFileChanges.TabIndex" type="System.Int32, mscorlib">
+    <value>39</value>
   </data>
-  <data name="dpsUpdateRateLabel.Text" xml:space="preserve">
-    <value>Dps update interval seconds (0=never)</value>
+  <data name="&gt;&gt;checkWatchFileChanges.Name" xml:space="preserve">
+    <value>checkWatchFileChanges</value>
   </data>
-  <data name="dpsUpdateRateLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRateLabel.Name" xml:space="preserve">
-    <value>dpsUpdateRateLabel</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRateLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRateLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRateLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="dpsUpdateRate.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="dpsUpdateRate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 1</value>
-  </data>
-  <data name="dpsUpdateRate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
-  </data>
-  <data name="dpsUpdateRate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>357, 20</value>
-  </data>
-  <data name="dpsUpdateRate.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRate.Name" xml:space="preserve">
-    <value>dpsUpdateRate</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRate.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;dpsUpdateRate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="logUpdateLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
-  </data>
-  <data name="logUpdateLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="logUpdateLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 22</value>
-  </data>
-  <data name="logUpdateLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 20</value>
-  </data>
-  <data name="logUpdateLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>33</value>
-  </data>
-  <data name="logUpdateLabel.Text" xml:space="preserve">
-    <value>Send log updates</value>
-  </data>
-  <data name="logUpdateLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;logUpdateLabel.Name" xml:space="preserve">
-    <value>logUpdateLabel</value>
-  </data>
-  <data name="&gt;&gt;logUpdateLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;logUpdateLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;logUpdateLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="logUpdateCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
-  </data>
-  <data name="logUpdateCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="logUpdateCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>208, 25</value>
-  </data>
-  <data name="logUpdateCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 14</value>
-  </data>
-  <data name="logUpdateCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;logUpdateCheckBox.Name" xml:space="preserve">
-    <value>logUpdateCheckBox</value>
-  </data>
-  <data name="&gt;&gt;logUpdateCheckBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;checkWatchFileChanges.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;logUpdateCheckBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;checkWatchFileChanges.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;logUpdateCheckBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;checkWatchFileChanges.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="restartMessageLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
-  </data>
-  <data name="restartMessageLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="labelDevReloader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="restartMessageLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>208, 42</value>
-  </data>
-  <data name="restartMessageLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>282, 13</value>
-  </data>
-  <data name="restartMessageLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>35</value>
-  </data>
-  <data name="restartMessageLabel.Text" xml:space="preserve">
-    <value>※Restart the plugin to apply update rate / hotkey changes</value>
-  </data>
-  <data name="restartMessageLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;restartMessageLabel.Name" xml:space="preserve">
-    <value>restartMessageLabel</value>
-  </data>
-  <data name="&gt;&gt;restartMessageLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;restartMessageLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;restartMessageLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="labelDevReloader.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 55</value>
+  <data name="labelDevReloader.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 23</value>
+  <data name="labelDevReloader.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>36</value>
+  <data name="labelDevReloader.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 20</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Custom User Config Directory</value>
+  <data name="labelDevReloader.TabIndex" type="System.Int32, mscorlib">
+    <value>38</value>
   </data>
-  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+  <data name="labelDevReloader.Text" xml:space="preserve">
+    <value>Reload overlay on file change</value>
+  </data>
+  <data name="labelDevReloader.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
+  <data name="&gt;&gt;labelDevReloader.Name" xml:space="preserve">
+    <value>labelDevReloader</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+  <data name="&gt;&gt;labelDevReloader.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;labelDevReloader.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;labelDevReloader.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
@@ -412,7 +250,7 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 56</value>
+    <value>206, 1</value>
   </data>
   <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
@@ -436,67 +274,82 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel4.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="buttonSelectUserConfigFile" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="textUserConfigFile" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,37" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="labelDevReloader.AutoSize" type="System.Boolean, mscorlib">
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelDevReloader.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="labelDevReloader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 78</value>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="labelDevReloader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 20</value>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
   </data>
-  <data name="labelDevReloader.TabIndex" type="System.Int32, mscorlib">
-    <value>38</value>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 23</value>
   </data>
-  <data name="labelDevReloader.Text" xml:space="preserve">
-    <value>Reload overlay on file change</value>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
   </data>
-  <data name="labelDevReloader.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+  <data name="label1.Text" xml:space="preserve">
+    <value>Custom User Config Directory</value>
+  </data>
+  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
-  <data name="&gt;&gt;labelDevReloader.Name" xml:space="preserve">
-    <value>labelDevReloader</value>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
   </data>
-  <data name="&gt;&gt;labelDevReloader.Type" xml:space="preserve">
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;labelDevReloader.Parent" xml:space="preserve">
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;labelDevReloader.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="checkWatchFileChanges.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tableLayoutPanel3.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="checkWatchFileChanges.Location" type="System.Drawing.Point, System.Drawing">
-    <value>208, 81</value>
+  <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>208, 46</value>
   </data>
-  <data name="checkWatchFileChanges.Size" type="System.Drawing.Size, System.Drawing">
-    <value>353, 14</value>
+  <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="checkWatchFileChanges.TabIndex" type="System.Int32, mscorlib">
-    <value>39</value>
+  <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>353, 551</value>
   </data>
-  <data name="&gt;&gt;checkWatchFileChanges.Name" xml:space="preserve">
-    <value>checkWatchFileChanges</value>
+  <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
   </data>
-  <data name="&gt;&gt;checkWatchFileChanges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tableLayoutPanel3.Name" xml:space="preserve">
+    <value>tableLayoutPanel3</value>
   </data>
-  <data name="&gt;&gt;checkWatchFileChanges.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;checkWatchFileChanges.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;tableLayoutPanel3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls /&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -526,7 +379,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tableLayoutPanel3" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="dpsUpdateRateLabel" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="dpsUpdateRate" Row="8" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="logUpdateLabel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="logUpdateCheckBox" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="restartMessageLabel" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="12" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel4" Row="12" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDevReloader" Row="13" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkWatchFileChanges" Row="13" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,205,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,23,Absolute,20,Absolute,30" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tableLayoutPanel3" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="12" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel4" Row="12" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDevReloader" Row="13" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkWatchFileChanges" Row="13" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,205,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,23,Absolute,20,Absolute,30" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
dps update rate no longer makes sense given that the miniparse event
source is sending dps updates.

Additionally, as logs aren't sent to anything that don't need it,
there's no need for a log-related checkbox either.